### PR TITLE
fix: goto<four bytes forward>

### DIFF
--- a/src/blog/2019-12-30-jvm-hackery-noverify.md
+++ b/src/blog/2019-12-30-jvm-hackery-noverify.md
@@ -63,7 +63,7 @@ But if we peruse the [Java bytecode instruction listings](https://en.wikipedia.o
 Therefore, we can manipulate our `goto` instruction to jump into the middle of our immediate `short` constant that usually would act as the operand to `sipush`:
 
 <pre><code class="hljs-manual language-javabytecode"><span class="hljs-function"><span class="hljs-keyword">public</span> <span class="hljs-keyword">int</span> myWeirdMethod():</span>
-  <span class="hljs-keyword">goto</span> &lt;two bytes forward&gt;
+  <span class="hljs-keyword">goto</span> &lt;four bytes forward&gt;
   <span class="hljs-keyword">sipush</span> <span class="hljs-number">0x06ac</span>
   <span class="hljs-keyword">ireturn</span>
 


### PR DESCRIPTION
[sample.zip](https://github.com/videogame-hacker/som.codes/files/8546854/sample.zip)

bytecodes of the main method:
```java
public static main([Ljava/lang/String;)V
    GETSTATIC java/lang/System.out : Ljava/io/PrintStream;
    LDC "hello"
    INVOKEVIRTUAL java/io/PrintStream.println (Ljava/lang/String;)V
    GOTO <four bytes forward>
    BIPUSH 0xb1
    //instructions below should't be executed
    ACONST_NULL
    ATHROW
```

hexdump:
![hexdump](https://user-images.githubusercontent.com/60530949/164893676-56192dd9-ffc8-4cd2-b218-4a8d992d3056.png)

Just as the image shows, in this case we should go 4 bytes forward ( 2 bytes for branchbyte1 and branchbyte2 of the GOTO instruction, 1 byte for BIPUSH's opcode and 1 byte for the target byte itself) to RETURN(0xb1) instruction.
Similarly, the case "GOTO and SIPUSH" should also go 4 bytes forward (2 bytes for branchbyte1 and branchbyte2 of the GOTO instruction, 1 byte for SIPUSH's opcode and 1 byte for the 1st target byte itself)



